### PR TITLE
API endpoints return 4xx/5xx status codes on error

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,3 +112,22 @@ jobs:
             --helm-extra-args '--timeout 60s' \
             --helm-extra-set-args '--set=image.tag=${{ needs.build.outputs.releaseTag }}' \
             --target-branch ${{ github.event.repository.default_branch }}
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.10.0
+
+      - name: Integration tests
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          pytest -m integration

--- a/kron.py
+++ b/kron.py
@@ -1,4 +1,4 @@
-import logging
+import json, logging
 
 from kubernetes import client
 from kubernetes import config as kubeconfig
@@ -6,6 +6,7 @@ from kubernetes.config import ConfigException
 from kubernetes.client.rest import ApiException
 from datetime import datetime, timezone
 from typing import List
+from werkzeug import exceptions
 
 import config
 
@@ -119,6 +120,19 @@ def _has_label(api_object: object, k: str, v: str) -> bool:
     return labels.get(k) == v
 
 
+def _api_exception_to_http_exception(e: ApiException):
+    """
+    Convert a Kubernetes ApiException into a HTTP exception.
+    """
+    log.error(e)
+    description = json.loads(e.body)["message"]
+    if e.status in [401, 403]:
+        return exceptions.Forbidden(description=description)
+    if e.status == 404:
+        return exceptions.NotFound(description=description)
+    return exceptions.InternalServerError("Something went wrong")
+
+
 def pod_is_owned_by(api_dict: dict, owner_name: str) -> bool:
     """Return whether a job or pod contains an ownerReference to the given cronjob or job name
 
@@ -176,16 +190,7 @@ def get_cronjobs(namespace: str = None) -> List[dict]:
         return sorted_cronjobs
 
     except ApiException as e:
-        log.error(e)
-        response = {
-            "error": 500,
-            "exception": {
-                "status": e.status,
-                "reason": e.reason,
-                "message": e.body["message"],
-            },
-        }
-        return response
+        raise _api_exception_to_http_exception(e)
 
 
 @namespace_filter
@@ -202,8 +207,8 @@ def get_cronjob(namespace: str, cronjob_name: str) -> dict:
     try:
         cronjob = batch.read_namespaced_cron_job(cronjob_name, namespace)
         return _clean_api_object(cronjob)
-    except ApiException:
-        return False
+    except ApiException as e:
+        raise _api_exception_to_http_exception(e)
 
 
 @namespace_filter
@@ -270,16 +275,7 @@ def get_pods(namespace: str, job_name: str = None) -> List[dict]:
         return filtered_pods
 
     except ApiException as e:
-        log.error(e)
-        response = {
-            "error": 500,
-            "exception": {
-                "status": e.status,
-                "reason": e.reason,
-                "message": e.body["message"],
-            },
-        }
-        return response
+        raise _api_exception_to_http_exception(e)
 
 
 @namespace_filter
@@ -340,16 +336,7 @@ def trigger_cronjob(namespace: str, cronjob_name: str) -> dict:
         return _clean_api_object(trigger_job)
 
     except ApiException as e:
-        log.error(e)
-        response = {
-            "error": 500,
-            "exception": {
-                "status": e.status,
-                "reason": e.reason,
-                "message": e.body["message"],
-            },
-        }
-        return response
+        raise _api_exception_to_http_exception(e)
 
 
 @namespace_filter
@@ -374,16 +361,7 @@ def toggle_cronjob_suspend(namespace: str, cronjob_name: str) -> dict:
         return _clean_api_object(cronjob)
 
     except ApiException as e:
-        log.error(e)
-        response = {
-            "error": 500,
-            "exception": {
-                "status": e.status,
-                "reason": e.reason,
-                "message": e.body["message"],
-            },
-        }
-        return response
+        raise _api_exception_to_http_exception(e)
 
 
 @namespace_filter
@@ -399,23 +377,15 @@ def update_cronjob(namespace: str, spec: str) -> dict:
     """
     try:
         name = spec["metadata"]["name"]
-        if get_cronjob(namespace, name):
+        try:
             cronjob = batch.patch_namespaced_cron_job(name, namespace, spec)
-        else:
+        except ApiException as e:
+            # TODO: e may be e.g. Forbidden
             cronjob = batch.create_namespaced_cron_job(namespace, spec)
         return _clean_api_object(cronjob)
 
     except ApiException as e:
-        log.error(e)
-        response = {
-            "error": 500,
-            "exception": {
-                "status": e.status,
-                "reason": e.reason,
-                "message": e.body["message"],
-            },
-        }
-        return response
+        raise _api_exception_to_http_exception(e)
 
 
 @namespace_filter
@@ -434,16 +404,7 @@ def delete_cronjob(namespace: str, cronjob_name: str) -> dict:
         return _clean_api_object(deleted)
 
     except ApiException as e:
-        log.error(e)
-        response = {
-            "error": 500,
-            "exception": {
-                "status": e.status,
-                "reason": e.reason,
-                "message": e.body["message"],
-            },
-        }
-        return response
+        raise _api_exception_to_http_exception(e)
 
 
 @namespace_filter
@@ -462,13 +423,4 @@ def delete_job(namespace: str, job_name: str) -> dict:
         return _clean_api_object(deleted)
 
     except ApiException as e:
-        log.error(e)
-        response = {
-            "error": 500,
-            "exception": {
-                "status": e.status,
-                "reason": e.reason,
-                "message": e.body["message"],
-            },
-        }
-        return response
+        raise _api_exception_to_http_exception(e)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: tests that require access to a k8s cluster
+addopts = -m "not integration"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,94 @@
+import os.path, sys, uuid
+
+from pytest import fixture, mark
+from kubernetes import client, config as k8s_config, utils
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+try:
+    from app import app
+except Exception as e:
+    pass
+
+
+@fixture
+def k8s_client():
+    k8s_config.load_kube_config()
+    return client.ApiClient()
+
+
+@fixture
+def namespace(k8s_client):
+    name = str(uuid.uuid4())
+    manifest = {"apiVersion": "v1", "kind": "Namespace", "metadata": {"name": name}}
+    utils.create_from_dict(k8s_client, manifest)
+    yield name
+    corev1 = client.CoreV1Api(k8s_client)
+    corev1.delete_namespace(name)
+
+
+def create_cronjob(k8s_client, namespace):
+    name = str(uuid.uuid4())
+    manifest = {
+        "apiVersion": "batch/v1",
+        "kind": "CronJob",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {
+            "schedule": "0 0 * * *",
+            "jobTemplate": {
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "hello",
+                                    "image": "busybox:1.28",
+                                    "imagePullPolicy": "IfNotPresent",
+                                    "command": ["/bin/sh", "-c", "echo Hello"],
+                                }
+                            ],
+                            "restartPolicy": "Never",
+                        }
+                    }
+                }
+            },
+        },
+    }
+    utils.create_from_dict(k8s_client, manifest)
+    return name
+
+
+@fixture()
+def api():
+    app.config.update({"TESTING": True})
+    return app.test_client()
+
+
+@mark.integration
+def test_get_cronjob_missing(k8s_client, api, namespace):
+    res = api.get(f"/api/namespaces/{namespace}/cronjobs/nonsense")
+    assert res.status_code == 404
+    assert "nonsense" in res.data.decode("utf-8")
+
+
+@mark.integration
+def test_get_cronjob_succeeds(k8s_client, api, namespace):
+    name = create_cronjob(k8s_client, namespace)
+    res = api.get(f"/api/namespaces/{namespace}/cronjobs/{name}")
+    cronjob = res.json
+    assert cronjob["metadata"]["name"] == name
+    assert (
+        cronjob["spec"]["suspend"] == False
+    )  # K8s will have populated this by default
+
+
+@mark.integration
+def test_clone_cronjob_succeeds(k8s_client, api, namespace):
+    name = create_cronjob(k8s_client, namespace)
+    clone = f"clone-{name}"
+    res = api.post(
+        f"/api/namespaces/{namespace}/cronjobs/{name}/clone", json={"name": clone}
+    )
+    cronjob = res.json
+    assert res.status_code == 200
+    assert cronjob["metadata"]["name"] == clone


### PR DESCRIPTION
This PR should be seen as a sketch to start a discussion on:

- how and when to run tests on the API endpoints that can capture HTTP semantics
- how to communicate errors to the browser

Once we have a direction, I will split and rework this PR.